### PR TITLE
Fix the simple demo in duo_python to work in Safari.

### DIFF
--- a/demos/simple/server.py
+++ b/demos/simple/server.py
@@ -101,6 +101,10 @@ class RequestHandler(SimpleHTTPRequestHandler):
             return
         user = duo_web.verify_response(
             self.server.ikey, self.server.skey, self.server.akey, sig_response)
+
+        self.send_response(200)
+        self.end_headers()
+
         if user is None:
             # See if it was a response to an ENROLL_REQUEST
             user = duo_web.verify_enroll_response(self.server.ikey,


### PR DESCRIPTION
The demo used to send a text response without the proper HTTP response headers,
causing Safari to get confused.
