### PR TITLE
Removed redundant call to wraps

### DIFF
--- a/demos/django/duo_app/duo_auth.py
+++ b/demos/django/duo_app/duo_auth.py
@@ -64,8 +64,7 @@ def duo_auth_required(view_func, redirect_field_name=REDIRECT_FIELD_NAME):
             return HttpResponseRedirect(
                 '%s?%s=%s' % (
                     settings.DUO_LOGIN_URL, redirect_field_name, path))
-        return wraps(
-            view_func, assigned=available_attrs(view_func))(_wrapped_view)
+        return _wrapped_view
     return decorator(view_func)
 
 


### PR DESCRIPTION
The wraps python decorator was used (via the ampersand syntactic sugar) in addition to a separate decoartion in the function return. I removed the call in the function return in order to use the common sugary way of specifying python decorators.