### PR TITLE
Add title to demo iframes for accessibility

### DIFF
--- a/demos/appengine/app.py
+++ b/demos/appengine/app.py
@@ -98,6 +98,7 @@ class SecondaryAuthPage(BasePage):
             "    <h1>Duo Authentication</h1>"
             "      <script src='/static/Duo-Web-v2.js'></script>"
             "      <iframe id='duo_iframe'"
+            "              title='Two-Factor Authentication'"
             "              frameborder='0'"
             "              data-host='%(host)s'"
             "              data-sig-request='%(sig_request)s'"

--- a/demos/django/duo_app/templates/duo_login.html
+++ b/demos/django/duo_app/templates/duo_login.html
@@ -19,6 +19,7 @@
 
 <script src="{{ duo_js_src }}"></script>
 <iframe id="duo_iframe"
+        title="Two-Factor Authentication"
         frameborder="0"
         data-host="{{ duo_host }}"
         data-sig-request="{{ sig_request }}"

--- a/demos/openid/templates/secondary_auth.html
+++ b/demos/openid/templates/secondary_auth.html
@@ -17,7 +17,12 @@
 Duo.init({'host':'{{host}}', 'post_action':'{{post_action}}',
 'sig_request':'{{sig_request}}'});
 </script>
-<iframe height='500' width='620' frameborder='0' id='duo_iframe' />
+<iframe height='500'
+        width='620'
+        frameborder='0'
+        id='duo_iframe'
+        title='Two-Factor Authentication'
+        />
 
 </body>
 </html>

--- a/demos/simple/server.py
+++ b/demos/simple/server.py
@@ -97,6 +97,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
                 <h1>Duo Authentication</h1>
                 <script src='/Duo-Web-v2.js'></script>
                 <iframe id="duo_iframe"
+                        title="Two-Factor Authentication"
                         frameborder="0"
                         data-host="%(host)s"
                         data-sig-request="%(sig_request)s"


### PR DESCRIPTION
Having a title attribute on the iframe will help screen reader users figure out what the frame is for.

Based on this WCAG 2.0 requirement: [https://www.w3.org/TR/WCAG20-TECHS/H64.html](https://www.w3.org/TR/WCAG20-TECHS/H64.html)