### PR TITLE
Fixed path building

### DIFF
--- a/demos/django/duo_app/duo_auth.py
+++ b/demos/django/duo_app/duo_auth.py
@@ -11,7 +11,7 @@ from django.utils.http import urlquote
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 
-import duo_web
+import duo_web, os
 from six.moves.urllib.parse import urlencode
 
 
@@ -91,10 +91,10 @@ def login(request):
         context = {
             'message': message,
             'next': next_page,
-            'duo_css_src': '/'.join([settings.STATIC_URL,
-                                     'Duo-Frame.css']),
-            'duo_js_src': '/'.join([settings.STATIC_URL,
-                                     'Duo-Web-v2.js']),
+            'duo_css_src': os.path.join(settings.STATIC_URL,
+                                     'Duo-Frame.css'),
+            'duo_js_src': os.path.join(settings.STATIC_URL,
+                                     'Duo-Web-v2.js'),
             'duo_host': settings.DUO_HOST,
             'post_action': request.path,
             'sig_request': sig_request


### PR DESCRIPTION
File paths should generally be constructed using os.path.join() rather than concatenating strings with slashes
This was causing a double slash issue for me