### PR TITLE
Revert "Fixed path building"

### DIFF
--- a/demos/django/duo_app/duo_auth.py
+++ b/demos/django/duo_app/duo_auth.py
@@ -11,7 +11,7 @@ from django.utils.http import urlquote
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 
-import duo_web, os
+import duo_web
 from six.moves.urllib.parse import urlencode
 
 
@@ -91,10 +91,10 @@ def login(request):
         context = {
             'message': message,
             'next': next_page,
-            'duo_css_src': os.path.join(settings.STATIC_URL,
-                                     'Duo-Frame.css'),
-            'duo_js_src': os.path.join(settings.STATIC_URL,
-                                     'Duo-Web-v2.js'),
+            'duo_css_src': '/'.join([settings.STATIC_URL,
+                                     'Duo-Frame.css']),
+            'duo_js_src': '/'.join([settings.STATIC_URL,
+                                     'Duo-Web-v2.js']),
             'duo_host': settings.DUO_HOST,
             'post_action': request.path,
             'sig_request': sig_request


### PR DESCRIPTION
Reverts duosecurity/duo_python#16

os.path is for building file system paths, but the code in question is trying to build a URL.  If this code were to run on Windows it would build a path with backslashes instead of forward slashes, which isn't what we want.