### PR TITLE
Add tips about adding duo_auth_required to /admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,6 @@ $ cd duo_python
 $ pip install --requirement requirements-dev.txt
 ```
 
-## CRITICAL: Add Duo to logins for `/admin` as well
-
-The examples herein do not add Duo "everywhere" nor the Django admin site. **This is critical to recognize, because if you do not have 2FA on `/admin`, and you have `/admin` enabled, you essentially degrade to 1FA on the most sensitive part of your application.**
-
-Happily it is not difficult! You just have some choices to make about how to do it. 
-
-You can choose to add Duo "everywhere" (except login and logout) by applying middleware; [here is some discussion and examples of this approach](https://stackoverflow.com/questions/2164069/best-way-to-make-djangos-login-required-the-default). There is a [third party library, `django-stronghold`, which can achieve the same effect](https://github.com/mgrouchy/django-stronghold); however, you can avoid adding a dependency by just inlining your own middleware (it does not take much code).
-
-If you do not want to add it "everywhere" you can just make sure to add it to the admin site explicitly. Due to the typical "shortcut" fashion that admin views are added to your configuration, you have some choices to make in how you add the `duo_auth_required` decorator to all admin views. You basically want some helper to go through all child views and decorate them. [There are multiple approaches discussed here, including at least one third party library](https://stackoverflow.com/q/2307926/884640).
-
-Whichever way you choose to do it, don't leave the admin panel less secure!
-
 # Testing
 
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ $ cd duo_python
 $ pip install --requirement requirements-dev.txt
 ```
 
+## CRITICAL: Add Duo to logins for `/admin` as well
+
+The examples herein do not add Duo "everywhere" nor the Django admin site. **This is critical to recognize, because if you do not have 2FA on `/admin`, and you have `/admin` enabled, you essentially degrade to 1FA on the most sensitive part of your application.**
+
+Happily it is not difficult! You just have some choices to make about how to do it. 
+
+You can choose to add Duo "everywhere" (except login and logout) by applying middleware; [here is some discussion and examples of this approach](https://stackoverflow.com/questions/2164069/best-way-to-make-djangos-login-required-the-default). There is a [third party library, `django-stronghold`, which can achieve the same effect](https://github.com/mgrouchy/django-stronghold); however, you can avoid adding a dependency by just inlining your own middleware (it does not take much code).
+
+If you do not want to add it "everywhere" you can just make sure to add it to the admin site explicitly. Due to the typical "shortcut" fashion that admin views are added to your configuration, you have some choices to make in how you add the `duo_auth_required` decorator to all admin views. You basically want some helper to go through all child views and decorate them. [There are multiple approaches discussed here, including at least one third party library](https://stackoverflow.com/q/2307926/884640).
+
+Whichever way you choose to do it, don't leave the admin panel less secure!
+
 # Testing
 
 ```

--- a/demos/django/README.md
+++ b/demos/django/README.md
@@ -66,3 +66,16 @@ visiting /accounts/logout/ & /accounts/duo_logout/, respectively.
 
 Note that this example serves static files with the Django development server,
 which is not recommended for production.
+
+
+## Enable MFA for `/admin` login
+
+The examples herein do not add Duo "everywhere" nor the Django admin site. **This is critical to recognize, because if you do not have 2FA on `/admin`, and you have `/admin` enabled, you essentially degrade to 1FA on the most sensitive part of your application.**
+
+Happily it is not difficult! You just have some choices to make about how to do it. 
+
+You can choose to add Duo "everywhere" (except login and logout) by applying middleware; [here is some discussion and examples of this approach](https://stackoverflow.com/questions/2164069/best-way-to-make-djangos-login-required-the-default). There is a [third party library, `django-stronghold`, which can achieve the same effect](https://github.com/mgrouchy/django-stronghold); however, you can avoid adding a dependency by just inlining your own middleware (it does not take much code).
+
+If you do not want to add it "everywhere" you can just make sure to add it to the admin site explicitly. Due to the typical "shortcut" fashion that admin views are added to your configuration, you have some choices to make in how you add the `duo_auth_required` decorator to all admin views. You basically want some helper to go through all child views and decorate them. [There are multiple approaches discussed here, including at least one third party library](https://stackoverflow.com/q/2307926/884640).
+
+Whichever way you choose to do it, don't leave the admin panel less secure!


### PR DESCRIPTION
Will address #24. Had to take the approach of giving "various options," because there isn't a single best solution for all Django app maintainers. This is partly due to constraints in Django. Did my best to help explain the options while displaying a preference to a certain option (enable 2fa 'everywhere').