### PR TITLE
Add Python 3.7 to TravisCI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7-dev
 install:
     - pip install -r requirements-dev.txt
 script:


### PR DESCRIPTION
What it says on the tin. `3.7-dev` is the only current option at the moment but we'll want to change it to `3.7` later on when TravisCI makes that option available.