### PR TITLE
Update simple demo to allow multiple config sections

### DIFF
--- a/demos/simple/README.md
+++ b/demos/simple/README.md
@@ -46,6 +46,6 @@ host = host
 
 An optional parameter can be passed at runtime. If not provided, it will default to `duo`
 
-    python server.py duo_1
+    python server.py [-c|--config <config_section>]
 
 

--- a/demos/simple/README.md
+++ b/demos/simple/README.md
@@ -27,5 +27,25 @@ To run the server on port 8080:
 Visit the root URL with a 'user' argument, e.g.
 'http://localhost:8080/?user=myname'.
 
+# Multiple Configurations
+If desired, multiple configuration sections can be added to `duo.conf`:
+
+```
+[duo]
+ikey = ikey
+skey = skey
+akey = akey
+host = host
+
+[duo_1]
+ikey = ikey
+skey = skey
+akey = akey
+host = host
+```
+
+An optional parameter can be passed at runtime. If not provided, it will default to `duo`
+
+    python server.py duo_1
 
 

--- a/demos/simple/server.py
+++ b/demos/simple/server.py
@@ -4,6 +4,7 @@ from six.moves.urllib.parse import urlparse, parse_qs
 import cgi
 import os
 import sys
+import argparse
 
 import duo_web
 
@@ -153,6 +154,20 @@ def main(ikey, skey, akey, host, port=8080):
     print("'http://localhost:%d/?user=myname'." % port)
     server.serve_forever()
 
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "-c", "--config",
+        help="The config section from duo.conf to use",
+        default="duo",
+        metavar='')
+
+    return parser.parse_args()
+
+
 if __name__ == '__main__':
     import six.moves.configparser as ConfigParser
 
@@ -169,4 +184,5 @@ if __name__ == '__main__':
                 filename, directory))
         sys.exit(1)
 
-    main(**dict(config.items('duo')))
+    args = parse_args()
+    main(**dict(config.items(args.config)))


### PR DESCRIPTION
This allows multiple configuration sections to be defined in `duo.conf` for the `demos/simple` demo application. An example `[duo.conf]` with multiple configs could look like this:

```
[duo]
ikey = ikey1
skey = skey1
akey = akey1
host = host1

[duo_1]
ikey = ikey2
skey = skey2
akey = akey2
host = host2
```

This will allow devs to store and quickly switch between different configuration settings rather than repeatedly overwriting one config section.

The configuration is passed in to the command line. If not provided it will default do `duo`, so it can still be run with

```
python server.py
```

and optionally with

```
python server.py -c duo_1
```

or

```
python server.py --config duo_1
```