### PR TITLE
Use Helvetica Neue instead of Times New Roman in simple demo parent

### DIFF
--- a/demos/simple/Duo-Frame.css
+++ b/demos/simple/Duo-Frame.css
@@ -1,5 +1,10 @@
 body {
     text-align: center;
+    font-family: "Helvetica Neue", helvetica, arial, sans-serif;
+}
+
+h1 {
+    font-weight: 200;
 }
 
 iframe {


### PR DESCRIPTION
this is purely 𝕒𝕖𝕤𝕥𝕙𝕖𝕥𝕚𝕔 but the Times New Roman header in the simple demo is dissonant with the prompt and has always bothered me.

Much better: 

![image](https://user-images.githubusercontent.com/4042656/53591010-ec9deb80-3b47-11e9-94aa-ad20911761fc.png)
