### PR TITLE
Add Dlint and flake8 to CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501
+exclude = demos

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ python:
 install:
     - pip install -r requirements-dev.txt
 script:
+    - flake8
     - nose2

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ nose2
 # Linting
 
 ```
-$ flake8 --ignore=E501 duo_web/ tests/
+$ flake8
 ```
 
 # Support

--- a/duo_web/__init__.py
+++ b/duo_web/__init__.py
@@ -32,7 +32,7 @@ ERR_UNKNOWN = 'ERR|An unknown error has occurred.'
 
 
 def _hmac_sha1(key, msg):
-    ctx = hmac.new(key, msg, hashlib.sha1)
+    ctx = hmac.new(key, msg, hashlib.sha1)  # noqa: DUO130, HMAC-SHA1 still secure
     return ctx.hexdigest()
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 nose2
 flake8
+dlint

--- a/tests/test.py
+++ b/tests/test.py
@@ -64,13 +64,13 @@ class TestSDK(unittest.TestCase):
 
         request_sig = duo_web.sign_request(IKEY, SKEY, 'invalid' * 6, USER)
         duo_sig, invalid_app_sig = request_sig.split(':')
-        
+
         request_sig = duo_web.sign_enroll_request(IKEY, SKEY, AKEY, USER)
         duo_sig, valid_enroll_sig = request_sig.split(':')
-        
+
         request_sig = duo_web.sign_enroll_request(IKEY, SKEY, 'invalid' * 6, USER)
         duo_sig, invalid_enroll_sig = request_sig.split(':')
-        
+
         invalid_user = duo_web.verify_response(IKEY, SKEY, AKEY, INVALID_RESPONSE + ':' + valid_app_sig)
         self.assertEqual(invalid_user, None)
 
@@ -97,6 +97,7 @@ class TestSDK(unittest.TestCase):
 
         enroll_user = duo_web.verify_enroll_response(IKEY, SKEY, AKEY, FUTURE_ENROLL_RESPONSE + ':' + invalid_enroll_sig)
         self.assertEqual(enroll_user, None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi all,

Since we have this new fancy [static analysis tool](https://github.com/duo-labs/dlint) I figured this would be a great place to start running it :)

This PR includes a few separate changes:

- Added Dlint (so flake8) to CI process
- Moved flake8 options to config file so we can just run `flake8`
- Fixed a few basic flake8 issues
- Whitelisted `hashlib.sha1` use ([DUO130](https://github.com/duo-labs/dlint/blob/master/docs/linters/DUO130.md))
    - So yeah, [SHA1 is broken](https://shattered.io/)
    - But this [doesn't mean HMAC-SHA1 is broken](https://crypto.stackexchange.com/questions/26510/why-is-hmac-sha1-still-considered-secure)...